### PR TITLE
Add data inspection utility and new regression model components

### DIFF
--- a/src/component/data_inspector.py
+++ b/src/component/data_inspector.py
@@ -1,0 +1,85 @@
+"""Utilities for inspecting dataset structure."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Mapping, Optional
+
+import pandas as pd
+
+
+@dataclass
+class ColumnSummary:
+    """Summary information for a single column in a dataset."""
+
+    name: str
+    dtype: str
+    non_null_count: int
+    missing_count: int
+    unique_values: Optional[int]
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert the summary to a serialisable dictionary."""
+        return {
+            "name": self.name,
+            "dtype": self.dtype,
+            "non_null_count": self.non_null_count,
+            "missing_count": self.missing_count,
+            "unique_values": self.unique_values,
+        }
+
+
+class DataInspector:
+    """Inspect tabular data sources to understand their structure."""
+
+    def __init__(self, dataframe: pd.DataFrame):
+        """Initialise the inspector with a dataframe to analyse."""
+        self._df = dataframe.copy()
+
+    @classmethod
+    def from_csv(
+        cls, file_path: str, *, nrows: Optional[int] = None, encoding: Optional[str] = None
+    ) -> "DataInspector":
+        """Create an inspector instance by reading a CSV file."""
+        dataframe = pd.read_csv(file_path, nrows=nrows, encoding=encoding)
+        return cls(dataframe)
+
+    def column_summaries(self) -> List[ColumnSummary]:
+        """Produce per-column summaries including missingness and type information."""
+        summaries: List[ColumnSummary] = []
+        for column in self._df.columns:
+            series = self._df[column]
+            summaries.append(
+                ColumnSummary(
+                    name=column,
+                    dtype=str(series.dtype),
+                    non_null_count=int(series.notna().sum()),
+                    missing_count=int(series.isna().sum()),
+                    unique_values=int(series.nunique(dropna=True)) if series.ndim == 1 else None,
+                )
+            )
+        return summaries
+
+    def dataset_shape(self) -> Dict[str, int]:
+        """Return the dataset shape as a dictionary for easier serialisation."""
+        rows, columns = self._df.shape
+        return {"rows": int(rows), "columns": int(columns)}
+
+    def basic_statistics(self, include: Iterable[str] = ("number", "object")) -> Mapping[str, pd.DataFrame]:
+        """Return descriptive statistics by dtype category."""
+        stats: Dict[str, pd.DataFrame] = {}
+        for dtype_group in include:
+            try:
+                stats[dtype_group] = self._df.describe(include=[dtype_group]).transpose()
+            except ValueError:
+                # Raised when no columns of the requested dtype are present.
+                continue
+        return stats
+
+    def missing_value_report(self) -> pd.Series:
+        """Return the fraction of missing values per column."""
+        return self._df.isna().mean().sort_values(ascending=False)
+
+    def head(self, n: int = 5) -> pd.DataFrame:
+        """Return the first *n* records for manual inspection."""
+        return self._df.head(n)

--- a/src/component/glm_model.py
+++ b/src/component/glm_model.py
@@ -1,0 +1,74 @@
+"""Generalised linear model utilities for regression tasks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Optional, Tuple
+
+import numpy as np
+from sklearn.linear_model import TweedieRegressor
+from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import StandardScaler
+
+
+@dataclass
+class GLMConfig:
+    """Configuration for the Tweedie-based generalised linear regressor."""
+
+    test_size: float = 0.2
+    random_state: int = 42
+    power: float = 1.5
+    alpha: float = 0.0
+    l1_ratio: Optional[float] = None
+    max_iter: int = 1000
+
+
+@dataclass
+class GeneralizedLinearRegressionModel:
+    """Train and evaluate a Tweedie-based generalised linear regression model."""
+
+    config: GLMConfig = field(default_factory=GLMConfig)
+    scaler: Optional[StandardScaler] = field(default=None, init=False)
+    model: Optional[TweedieRegressor] = field(default=None, init=False)
+
+    def fit(self, X: np.ndarray, y: np.ndarray) -> Tuple[TweedieRegressor, Dict[str, float]]:
+        """Fit the GLM to the provided dataset and return validation metrics."""
+        X_train, X_valid, y_train, y_valid = train_test_split(
+            X,
+            y,
+            test_size=self.config.test_size,
+            random_state=self.config.random_state,
+        )
+
+        self.scaler = StandardScaler(with_mean=True, with_std=True)
+        X_train_scaled = self.scaler.fit_transform(X_train)
+        X_valid_scaled = self.scaler.transform(X_valid)
+
+        model = TweedieRegressor(
+            power=self.config.power,
+            alpha=self.config.alpha,
+            l1_ratio=self.config.l1_ratio,
+            max_iter=self.config.max_iter,
+        )
+        model.fit(X_train_scaled, y_train)
+        self.model = model
+
+        predictions = model.predict(X_valid_scaled)
+        metrics = self._compute_metrics(y_valid, predictions)
+        return model, metrics
+
+    def predict(self, X: np.ndarray) -> np.ndarray:
+        """Generate predictions using the fitted GLM."""
+        if self.model is None or self.scaler is None:
+            raise RuntimeError("Model has not been fitted yet.")
+        transformed = self.scaler.transform(X)
+        return self.model.predict(transformed)
+
+    @staticmethod
+    def _compute_metrics(y_true: np.ndarray, y_pred: np.ndarray) -> Dict[str, float]:
+        """Compute RMSE, MAE, and :math:`R^2` metrics."""
+        rmse = float(np.sqrt(mean_squared_error(y_true, y_pred)))
+        mae = float(mean_absolute_error(y_true, y_pred))
+        r2 = float(r2_score(y_true, y_pred))
+        return {"rmse": rmse, "mae": mae, "r2": r2}

--- a/src/component/xgboost_model.py
+++ b/src/component/xgboost_model.py
@@ -1,0 +1,106 @@
+"""XGBoost regression utilities for house-price modelling."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional, Tuple
+
+import numpy as np
+from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import StandardScaler
+import xgboost as xgb
+
+
+@dataclass
+class XGBoostConfig:
+    """Configuration parameters for the XGBoost regressor."""
+
+    test_size: float = 0.2
+    random_state: int = 42
+    n_estimators: int = 500
+    learning_rate: float = 0.05
+    max_depth: int = 6
+    subsample: float = 0.8
+    colsample_bytree: float = 0.8
+    reg_alpha: float = 0.0
+    reg_lambda: float = 1.0
+    early_stopping_rounds: int = 30
+    eval_metric: str = "rmse"
+
+    def to_model_kwargs(self) -> Dict[str, Any]:
+        """Return keyword arguments for :class:`xgboost.XGBRegressor`."""
+        return {
+            "n_estimators": self.n_estimators,
+            "learning_rate": self.learning_rate,
+            "max_depth": self.max_depth,
+            "subsample": self.subsample,
+            "colsample_bytree": self.colsample_bytree,
+            "reg_alpha": self.reg_alpha,
+            "reg_lambda": self.reg_lambda,
+            "random_state": self.random_state,
+            "objective": "reg:squarederror",
+            "tree_method": "hist",
+        }
+
+
+@dataclass
+class XGBoostRegressorModel:
+    """Train and evaluate an XGBoost regression model."""
+
+    config: XGBoostConfig = field(default_factory=XGBoostConfig)
+    scaler: Optional[StandardScaler] = field(default=None, init=False)
+    model: Optional[xgb.XGBRegressor] = field(default=None, init=False)
+
+    def fit(
+        self,
+        X: np.ndarray,
+        y: np.ndarray,
+        *,
+        eval_set_fraction: Optional[float] = None,
+    ) -> Tuple[xgb.XGBRegressor, Dict[str, float]]:
+        """Fit the model and return evaluation metrics on the validation split."""
+        if eval_set_fraction is None:
+            eval_set_fraction = self.config.test_size
+
+        X_train, X_valid, y_train, y_valid = train_test_split(
+            X,
+            y,
+            test_size=self.config.test_size,
+            random_state=self.config.random_state,
+        )
+
+        self.scaler = StandardScaler()
+        X_train_scaled = self.scaler.fit_transform(X_train)
+        X_valid_scaled = self.scaler.transform(X_valid)
+
+        model = xgb.XGBRegressor(**self.config.to_model_kwargs())
+        model.fit(
+            X_train_scaled,
+            y_train,
+            eval_set=[(X_valid_scaled, y_valid)],
+            eval_metric=self.config.eval_metric,
+            verbose=False,
+            early_stopping_rounds=self.config.early_stopping_rounds,
+        )
+
+        self.model = model
+
+        predictions = model.predict(X_valid_scaled)
+        metrics = self._compute_metrics(y_valid, predictions)
+        return model, metrics
+
+    def predict(self, X: np.ndarray) -> np.ndarray:
+        """Generate predictions using the fitted model."""
+        if self.model is None or self.scaler is None:
+            raise RuntimeError("Model has not been fitted yet.")
+        transformed = self.scaler.transform(X)
+        return self.model.predict(transformed)
+
+    @staticmethod
+    def _compute_metrics(y_true: np.ndarray, y_pred: np.ndarray) -> Dict[str, float]:
+        """Compute standard regression metrics for evaluation."""
+        rmse = float(np.sqrt(mean_squared_error(y_true, y_pred)))
+        mae = float(mean_absolute_error(y_true, y_pred))
+        r2 = float(r2_score(y_true, y_pred))
+        return {"rmse": rmse, "mae": mae, "r2": r2}

--- a/src/inspect_dataset.py
+++ b/src/inspect_dataset.py
@@ -1,0 +1,36 @@
+"""Command line utility to inspect the structure of the housing dataset."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from component.data_inspector import DataInspector
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("csv", type=Path, help="Path to the CSV file to inspect")
+    parser.add_argument("--head", type=int, default=5, help="Number of rows to preview")
+    args = parser.parse_args()
+
+    inspector = DataInspector.from_csv(str(args.csv))
+    shape = inspector.dataset_shape()
+    print(f"Rows: {shape['rows']:,} | Columns: {shape['columns']:,}")
+
+    print("\nMissing value report (sorted):")
+    report = inspector.missing_value_report()
+    print("Column                      Missing %")
+    print("-------------------------- ----------")
+    for column, fraction in report.items():
+        print(f"{column:<26} {fraction * 100:>9.2f}")
+
+    print("\nColumn summaries:")
+    for summary in inspector.column_summaries():
+        print(
+            f"- {summary.name} | dtype={summary.dtype} | non-null={summary.non_null_count:,} "
+            f"| missing={summary.missing_count:,} | unique={summary.unique_values}"
+        )
+
+    print("\nPreview:")
+    print(inspector.head(args.head))


### PR DESCRIPTION
## Summary
- add a reusable data inspector to summarize CSV structure and missingness
- implement standalone XGBoost and generalized linear regression model components with evaluation helpers
- include a simple CLI script for inspecting dataset metadata

## Testing
- python -m compileall src/component src/inspect_dataset.py

------
https://chatgpt.com/codex/tasks/task_e_68dc700009608330b2ba88878e705076